### PR TITLE
Change manifestUrl response parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:slim-buster
 
 WORKDIR /usr/src/app
 
+RUN mkdir /usr/src/app/import_manifest
+
 COPY requirements.txt ./
 RUN apt update && apt install git -y
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Wait a bit longer before giving up on manifestUrl and
search for it inside 'data' array, at index 0.

Fixes https://github.com/baycarbone/rancher-integrator/issues/1